### PR TITLE
Add "arm-none-eabi-objcopy" in docker

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,6 @@
 from ubuntu:18.04
 env LANG=C.UTF-8 LC_ALL=C.UTF-8
-run apt-get update && apt-get upgrade -y && apt-get install -y python python3 python3-pip automake tmux redis wget autoconf sudo htop cmake clang vim unzip git
+run apt-get update && apt-get upgrade -y && apt-get install -y python python3 python3-pip automake tmux redis wget autoconf sudo htop cmake clang vim unzip git binutils-arm-none-eabi
 run pip3 install virtualenv virtualenvwrapper cython setuptools
 
 arg USER_ID


### PR DESCRIPTION
Hello,

I try to use `fuzzware genconfig` to generate the config of other firmware which not in your dataset. And then I found that there are no `arm-none-eabi-objcopy` in the docker system. If the `.elf` file need to extract to `.bin` there will be an error.

I think the solution is to add `binutils-arm-none-eabi` in the `dockerfile` on 3 line. I made this change and it worked.

Best regards.