### PR TITLE
Fix broken links in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Directories within this repository. For the experiments in our paper, as well as
 | --------- | ----------- |
 | [docs](docs) | Documentation files (config optimizations, cov analysis, crash analysis). |
 | [examples](examples) | Target firmware samples to test Fuzzware on. |
-| [emulator](https://github.com/fuzzware-fuzzer/fuzzware-emulator) | The emulator which performs runs of a firmware for a given input file. |
+| [fuzzware-emulator](https://github.com/fuzzware-fuzzer/fuzzware-emulator) | The emulator which performs runs of a firmware for a given input file. |
 | [modeling](modeling) | MMIO modeling (based on angr). |
-| [pipeline](https://github.com/fuzzware-fuzzer/fuzzware-pipeline) | Orchestration between MMIO modeling and emulator. |
+| [fuzzware-pipeline](https://github.com/fuzzware-fuzzer/fuzzware-pipeline) | Orchestration between MMIO modeling and emulator. |
 | [scripts](scripts) | Some helper scripts (e.g., gather basic blocks in IDB). |
 | [fuzzware-experiments](https://github.com/fuzzware-fuzzer/fuzzware-experiments) | Pre-built images/config, crashing POCs/analyses, build scripts to re-run our experiments. |
 
@@ -36,8 +36,8 @@ To not let this document explode, we provide specific documentation in different
 
 1. Firmware targets, build scripts, example crash analyses: [the fuzzware-experiments repo](https://github.com/fuzzware-fuzzer/fuzzware-experiments)
 2. Fuzzware utilities documentation: `$ fuzzware -h`, and `$ fuzzware <util_name> -h`
-3. Firmware configuration file format details: [emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml)
-4. Fuzzware project result directory structure: [pipeline/README.md](https://github.com/fuzzware-fuzzer/fuzzware-pipeline/blob/main/README.md)
+3. Firmware configuration file format details: [fuzzware-emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml)
+4. Fuzzware project result directory structure: [fuzzware-pipeline/README.md](https://github.com/fuzzware-fuzzer/fuzzware-pipeline/blob/main/README.md)
 
 ## The Idea
 At its core, Fuzzware works by plugging an instruction emulator (currently: Unicorn Engine) to
@@ -51,8 +51,8 @@ a fuzzer (currently: afl) and having the fuzzer supply inputs for all hardware a
 ## Fuzzware Components
 Fuzzware is comprised of different components:
 
-1. [Pipeline Component (/pipeline)](https://github.com/fuzzware-fuzzer/fuzzware-pipeline): Integrated fuzzing and modeling. The pipeline component represents the glue between emulation and modeling. As the fuzzer/emulator finds new MMIO accesses during runs, the corresponding firmware states need to be forwarded to modeling. Similarly, the updated MMIO configurations produced during modeling need to be made available to the emulator. The Pipeline automates this cycle: It lets the emulator run, and pushes jobs for modeling newly observed MMIO accesses. It subsequently updates emulation with new models. The pipeline also implements additional features such as identifying successfully booted firmware states which are then automatically used for further fuzzing.
-2. [Emulation Component (/emulator)](https://github.com/fuzzware-fuzzer/fuzzware-emulator): Standalone single-input emulation runs. This component allows emulating a firmware image with a provided configuration for a particular input file. It handles the re-routing of fuzzing inputs to answer MMIO accesses as well as triggering interrupts and creating traces as well as state files for further processing. It also provides integration with a fuzzer (an AFL forkserver) for repeated emulation runs with different inputs.
+1. [Pipeline Component (fuzzware-pipeline)](https://github.com/fuzzware-fuzzer/fuzzware-pipeline): Integrated fuzzing and modeling. The pipeline component represents the glue between emulation and modeling. As the fuzzer/emulator finds new MMIO accesses during runs, the corresponding firmware states need to be forwarded to modeling. Similarly, the updated MMIO configurations produced during modeling need to be made available to the emulator. The Pipeline automates this cycle: It lets the emulator run, and pushes jobs for modeling newly observed MMIO accesses. It subsequently updates emulation with new models. The pipeline also implements additional features such as identifying successfully booted firmware states which are then automatically used for further fuzzing.
+2. [Emulation Component (fuzzware-emulator)](https://github.com/fuzzware-fuzzer/fuzzware-emulator): Standalone single-input emulation runs. This component allows emulating a firmware image with a provided configuration for a particular input file. It handles the re-routing of fuzzing inputs to answer MMIO accesses as well as triggering interrupts and creating traces as well as state files for further processing. It also provides integration with a fuzzer (an AFL forkserver) for repeated emulation runs with different inputs.
 3. [Modeling Component (/modeling)](modeling): Standalone modeling. This component generates MMIO access models for states exported by the emulation component. It does so by performing symbolic execution and analyzing what is happening to the accessed MMIO values. It outputs configuration snippets which can be fed back to the emulation component for improved emulation.
 
 For more information on the different components, please refer to the corresponding component subdirectories and READMEs.
@@ -96,7 +96,7 @@ workon fuzzware
 ```
 
 # Configuring Firmware Images For Fuzzing
-Find a detailed overview of configuration options in [emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml).
+Find a detailed overview of configuration options in [fuzzware-emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml).
 
 At minimum, you will need a bare-metal firmware blob and know where it is located in memory. With this, you can setup a memory map. For a firmware blob `fw.bin` located at address `0x08000000` in ROM, a config located in a newly created `examples/my-fw` directory would look like this:
 ```
@@ -138,7 +138,7 @@ If you want to get the best out of Fuzzware (as a human in the loop), you should
 2. Configure basic memory ranges: Create config manually or use `fuzzware genconfig` (works best with elf files, still take the output with a grain of salt and verify manually!)
 3. Fuzz the target: `fuzzware pipeline`
 4. Check coverage: `fuzzware cov`, `fuzzware cov -o cov.txt` and `fuzzware cov <target_function>`, `fuzzware replay --covering <target_function>`
-5. Adapt the configuration: [emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml) and fuzz again. If the image requires a rebuild, go to step 1. If the config needs adaption, goto step 3.
+5. Adapt the configuration: [fuzzware-emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml) and fuzz again. If the image requires a rebuild, go to step 1. If the config needs adaption, goto step 3.
 6. Once you are reasonably sure that meaningful functionality is reached in the current setup, it might make sense to scale up cores: `fuzzware pipeline -n 16`.
 7. Check for crashes: `fuzzware genstats crashcontexts`
 8. Replay and analyze crashes: `fuzzware replay -M -t mainXXX/fuzzers/fuzzerY/crashes/idZZZ`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The idea of this project is to configure the memory ranges of an ARM Cortex-M3 /
 
 Our [paper](https://www.usenix.org/system/files/sec22summer_scharnowski.pdf) from USENIX Security '22 explains the system in more detail.
 
-The [fuzzware-experiments repository](fuzzware-experiments) contains the data sets, scripts, and documentation required to replicate our experiments.
+The [fuzzware-experiments repository](https://github.com/fuzzware-fuzzer/fuzzware-experiments) contains the data sets, scripts, and documentation required to replicate our experiments.
 
 ## Quick Start
 First install:
@@ -26,9 +26,9 @@ Directories within this repository. For the experiments in our paper, as well as
 | --------- | ----------- |
 | [docs](docs) | Documentation files (config optimizations, cov analysis, crash analysis). |
 | [examples](examples) | Target firmware samples to test Fuzzware on. |
-| [emulator](emulator) | The emulator which performs runs of a firmware for a given input file. |
+| [emulator](https://github.com/fuzzware-fuzzer/fuzzware-emulator) | The emulator which performs runs of a firmware for a given input file. |
 | [modeling](modeling) | MMIO modeling (based on angr). |
-| [pipeline](pipeline) | Orchestration between MMIO modeling and emulator. |
+| [pipeline](https://github.com/fuzzware-fuzzer/fuzzware-pipeline) | Orchestration between MMIO modeling and emulator. |
 | [scripts](scripts) | Some helper scripts (e.g., gather basic blocks in IDB). |
 | [fuzzware-experiments](https://github.com/fuzzware-fuzzer/fuzzware-experiments) | Pre-built images/config, crashing POCs/analyses, build scripts to re-run our experiments. |
 
@@ -36,8 +36,8 @@ To not let this document explode, we provide specific documentation in different
 
 1. Firmware targets, build scripts, example crash analyses: [the fuzzware-experiments repo](https://github.com/fuzzware-fuzzer/fuzzware-experiments)
 2. Fuzzware utilities documentation: `$ fuzzware -h`, and `$ fuzzware <util_name> -h`
-3. Firmware configuration file format details: [emulator/README_config.yml](emulator/README_config.yml)
-4. Fuzzware project result directory structure: [pipeline/README.md](pipeline/README.md)
+3. Firmware configuration file format details: [emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml)
+4. Fuzzware project result directory structure: [pipeline/README.md](https://github.com/fuzzware-fuzzer/fuzzware-pipeline/blob/main/README.md)
 
 ## The Idea
 At its core, Fuzzware works by plugging an instruction emulator (currently: Unicorn Engine) to
@@ -51,8 +51,8 @@ a fuzzer (currently: afl) and having the fuzzer supply inputs for all hardware a
 ## Fuzzware Components
 Fuzzware is comprised of different components:
 
-1. [Pipeline Component (/pipeline)](pipeline): Integrated fuzzing and modeling. The pipeline component represents the glue between emulation and modeling. As the fuzzer/emulator finds new MMIO accesses during runs, the corresponding firmware states need to be forwarded to modeling. Similarly, the updated MMIO configurations produced during modeling need to be made available to the emulator. The Pipeline automates this cycle: It lets the emulator run, and pushes jobs for modeling newly observed MMIO accesses. It subsequently updates emulation with new models. The pipeline also implements additional features such as identifying successfully booted firmware states which are then automatically used for further fuzzing.
-2. [Emulation Component (/emulator)](emulator): Standalone single-input emulation runs. This component allows emulating a firmware image with a provided configuration for a particular input file. It handles the re-routing of fuzzing inputs to answer MMIO accesses as well as triggering interrupts and creating traces as well as state files for further processing. It also provides integration with a fuzzer (an AFL forkserver) for repeated emulation runs with different inputs.
+1. [Pipeline Component (/pipeline)](https://github.com/fuzzware-fuzzer/fuzzware-pipeline): Integrated fuzzing and modeling. The pipeline component represents the glue between emulation and modeling. As the fuzzer/emulator finds new MMIO accesses during runs, the corresponding firmware states need to be forwarded to modeling. Similarly, the updated MMIO configurations produced during modeling need to be made available to the emulator. The Pipeline automates this cycle: It lets the emulator run, and pushes jobs for modeling newly observed MMIO accesses. It subsequently updates emulation with new models. The pipeline also implements additional features such as identifying successfully booted firmware states which are then automatically used for further fuzzing.
+2. [Emulation Component (/emulator)](https://github.com/fuzzware-fuzzer/fuzzware-emulator): Standalone single-input emulation runs. This component allows emulating a firmware image with a provided configuration for a particular input file. It handles the re-routing of fuzzing inputs to answer MMIO accesses as well as triggering interrupts and creating traces as well as state files for further processing. It also provides integration with a fuzzer (an AFL forkserver) for repeated emulation runs with different inputs.
 3. [Modeling Component (/modeling)](modeling): Standalone modeling. This component generates MMIO access models for states exported by the emulation component. It does so by performing symbolic execution and analyzing what is happening to the accessed MMIO values. It outputs configuration snippets which can be fed back to the emulation component for improved emulation.
 
 For more information on the different components, please refer to the corresponding component subdirectories and READMEs.
@@ -96,7 +96,7 @@ workon fuzzware
 ```
 
 # Configuring Firmware Images For Fuzzing
-Find a detailed overview of configuration options in [emulator/README_config.yml](emulator/README_config.yml).
+Find a detailed overview of configuration options in [emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml).
 
 At minimum, you will need a bare-metal firmware blob and know where it is located in memory. With this, you can setup a memory map. For a firmware blob `fw.bin` located at address `0x08000000` in ROM, a config located in a newly created `examples/my-fw` directory would look like this:
 ```
@@ -116,7 +116,7 @@ Alternatively, you may also try out the experimental `fuzzware genconfig` utilit
 
 This will get your firmware image up and running initially. There are different additional configuration options to set which are specific to a firmware image and can support hardware features such as DMA, increase performance / decrease MMIO overhead, guide the firmware boot process, focus the fuzzer on specific interrupts, add introspection and debug symbols.
 
-An inline-documentation of firmware image configuration features can be found in [the config README of the emulator](emulator/README_config.yml). These configuration options allow you to configure different aspects concerning:
+An inline-documentation of firmware image configuration features can be found in [the config README of the emulator](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml). These configuration options allow you to configure different aspects concerning:
 - Interrupt raising (When? Which? How often?)
 - Firmware Boot guidance (snapshot state after boot is successful)
 - Symbols
@@ -138,7 +138,7 @@ If you want to get the best out of Fuzzware (as a human in the loop), you should
 2. Configure basic memory ranges: Create config manually or use `fuzzware genconfig` (works best with elf files, still take the output with a grain of salt and verify manually!)
 3. Fuzz the target: `fuzzware pipeline`
 4. Check coverage: `fuzzware cov`, `fuzzware cov -o cov.txt` and `fuzzware cov <target_function>`, `fuzzware replay --covering <target_function>`
-5. Adapt the configuration: [emulator/README_config.yml](emulator/README_config.yml) and fuzz again. If the image requires a rebuild, go to step 1. If the config needs adaption, goto step 3.
+5. Adapt the configuration: [emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml) and fuzz again. If the image requires a rebuild, go to step 1. If the config needs adaption, goto step 3.
 6. Once you are reasonably sure that meaningful functionality is reached in the current setup, it might make sense to scale up cores: `fuzzware pipeline -n 16`.
 7. Check for crashes: `fuzzware genstats crashcontexts`
 8. Replay and analyze crashes: `fuzzware replay -M -t mainXXX/fuzzers/fuzzerY/crashes/idZZZ`
@@ -198,4 +198,4 @@ As a researcher, time for coding is finite. This is why there are still TODOs wh
 3. **CompCov**: Currently, Fuzzware does not make use of some AFL++ features such as compcov. This would be an opportunity to integrate some more such features into unicorn.
 4. **Crash Analysis Tooling**: Currently, analyzing crashes is a largely manual task. However, Fuzzware contains code to generate and parse detailed traces, and to inject custom hooks during firmware emulation. Some more tooling based on traces and custom hooks could be created to easen the crash analysis process.
 5. **Input Patching Tooling**: Currently, manually modifying existing inputs is a manual task and involves manually interpreting MMIO trace files to match file contents to MMIO accesses. With proper tooling, modifying inputs could be made much more convenient, making it practical to manually create seed inputs which trigger important coverage, or more easily craft a proof-of-concept exploit from a given crashing input. These could then be used as a starting point for the fuzzer.
-6. **Refactoring**: When looking through the code you will certainly find grown pieces of code which could make use of cleanup and larger refactoring. To make your search easy, one such place is [naming_conventions.py](pipeline/fuzzware_pipeline/naming_conventions.py). Prior to publication, we did some cleanup, but also dedicated extra time to adding more tooling functionality in the hopes that it makes Fuzzware more easy for people to use and get into, without having to use some of the bash ugliness that you get away with as the author of a tool. As coding time is limited for us, we appreciate any community efforts in making the code better.
+6. **Refactoring**: When looking through the code you will certainly find grown pieces of code which could make use of cleanup and larger refactoring. To make your search easy, one such place is [naming_conventions.py](https://github.com/fuzzware-fuzzer/fuzzware-pipeline/blob/main/fuzzware_pipeline/naming_conventions.py). Prior to publication, we did some cleanup, but also dedicated extra time to adding more tooling functionality in the hopes that it makes Fuzzware more easy for people to use and get into, without having to use some of the bash ugliness that you get away with as the author of a tool. As coding time is limited for us, we appreciate any community efforts in making the code better.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ The following files are meant to give you additional insight into how to use and
 | [crash_analysis.md](crash_analysis.md) | Checking for crashes, bucketing them, and analyzing their root cause. |
 | [fuzzware_utils.md](fuzzware_utils.md) | An overview of some of the (other) Fuzzware tools and when they could be useful |
 | [manipulating_inputs.md](manipulating_inputs.md) | How to understand and manipulate inputs on your own, if you really need to |
-| [/emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml) | A pretty detailed (even if maybe not quite definitive) description of the config.yml syntax and supported options. |
-| [/pipeline/README.md](https://github.com/fuzzware-fuzzer/fuzzware-pipeline/blob/main/README_pipeline_architecture.md) | An overview of the how the pipeline component is implented. |
+| [fuzzware-emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml) | A pretty detailed (even if maybe not quite definitive) description of the config.yml syntax and supported options. |
+| [fuzzware-pipeline/README.md](https://github.com/fuzzware-fuzzer/fuzzware-pipeline/blob/main/README_pipeline_architecture.md) | An overview of the how the pipeline component is implented. |
 
 As always, you don't necessarily need to treat the code itself as a black box. Feel free to also check out the emulator- as well as the pipeline source code itself.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ The following files are meant to give you additional insight into how to use and
 | [crash_analysis.md](crash_analysis.md) | Checking for crashes, bucketing them, and analyzing their root cause. |
 | [fuzzware_utils.md](fuzzware_utils.md) | An overview of some of the (other) Fuzzware tools and when they could be useful |
 | [manipulating_inputs.md](manipulating_inputs.md) | How to understand and manipulate inputs on your own, if you really need to |
-| [/emulator/README_config.yml](../emulator/README_config.yml) | A pretty detailed (even if maybe not quite definitive) description of the config.yml syntax and supported options. |
-| [/pipeline/README.md](../pipeline/README_pipeline_architecture.md) | An overview of the how the pipeline component is implented. |
+| [/emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml) | A pretty detailed (even if maybe not quite definitive) description of the config.yml syntax and supported options. |
+| [/pipeline/README.md](https://github.com/fuzzware-fuzzer/fuzzware-pipeline/blob/main/README_pipeline_architecture.md) | An overview of the how the pipeline component is implented. |
 
 As always, you don't necessarily need to treat the code itself as a black box. Feel free to also check out the emulator- as well as the pipeline source code itself.

--- a/docs/crash_analysis.md
+++ b/docs/crash_analysis.md
@@ -116,9 +116,9 @@ handlers:
 
 **NOTE: Make sure to copy and modify the config.yml from the mainXXX directory that the given inputs belongs to. Otherwise, MMIO models will be missing/mismatching and the run will not replay as expected. For example, for the third main directory, create a backup and modify fuzzware-project/main003/config.yml. Once outside the fuzzware-project directory, you will also need to use the plain "fuzzware emu" utility instead of the "fuzzware replay" utility to run inputs for the given configuration.**
 
-As an example, please refer to the [crashing POC of CVE-2021-3329](https://github.com/fuzzware-fuzzer/fuzzware-experiments/03-fuzzing-new-targets/zephyr-os/prebuilt_samples/CVE-2021-3329/POC/config.yml) to see how these hooks can make understanding a given crash significantly simpler.
+As an example, please refer to the [crashing POC of CVE-2021-3329](https://github.com/fuzzware-fuzzer/fuzzware-experiments/blob/main/03-fuzzing-new-targets/zephyr-os/prebuilt_samples/CVE-2021-3329/POC/config.yml) to see how these hooks can make understanding a given crash significantly simpler.
 
-Also, for an example of a set of generic debug print hooks (do not use in the fuzzing configuration itself!), refer to [zephyr_debug_snippets.yml](https://github.com/fuzzware-fuzzer/fuzzware-experiments/03-fuzzing-new-targets/zephyr-os/building/base_configs/zephyr_debug_snippets.yml) within the fuzzware-experiments repo.
+Also, for an example of a set of generic debug print hooks (do not use in the fuzzing configuration itself!), refer to [zephyr_debug_snippets.yml](https://github.com/fuzzware-fuzzer/fuzzware-experiments/blob/main/03-fuzzing-new-targets/zephyr-os/building/base_configs/zephyr_debug_snippets.yml) within the fuzzware-experiments repo.
 
 ## Scripting A Trace Analysis
 

--- a/docs/fuzzware_utils.md
+++ b/docs/fuzzware_utils.md
@@ -21,7 +21,7 @@ workon fuzzware
 ## Starting the Pipeline
 The pipeline is what you want to be using whenever you start fuzzing a firmware image as it automatically manages fuzzing and model generation for you. It will generate the configurations and inputs that you can use to perform manual triaging and troubleshooting.
 
-For a properly configured firmware image and when within the installed `fuzzware` docker container or the `fuzzware` virtualenv on your locally installed system, you can get started by simply navigating to a correctly configured target directory in [the examples subdirectory](examples) and starting the pipeline with default arguments:
+For a properly configured firmware image and when within the installed `fuzzware` docker container or the `fuzzware` virtualenv on your locally installed system, you can get started by simply navigating to a correctly configured target directory in [the examples subdirectory](../examples) and starting the pipeline with default arguments:
 
 Using Docker:
 ```
@@ -39,7 +39,7 @@ This will create a `fuzzware-project` subdirectory and start the full pipeline w
 - `fuzzware-project/mainXXX/fuzzers/fuzzerY/queue`: Fuzzer inputs
 - `fuzzware-project/mainXXX/fuzzers/fuzzerY/traces`: Pipeline-generated compact traces (detailed traces can be generated manually using `fuzzware replay` or `fuzzware emu`)
 
-For more information on the results stored in the `fuzzware-project` directory, refer to the pipeline's README [pipeline/README.md](pipeline/README.md).
+For more information on the results stored in the `fuzzware-project` directory, refer to the pipeline's README [pipeline/README.md](https://github.com/fuzzware-fuzzer/fuzzware-pipeline/blob/main/README.md).
 
 There are situations where you might want to use a sub-component in isolation. This may be the case for troubleshooting, debugging, crash triaging and during fuzzware development. For a full list of supported commands, use:
 ```

--- a/docs/fuzzware_utils.md
+++ b/docs/fuzzware_utils.md
@@ -39,7 +39,7 @@ This will create a `fuzzware-project` subdirectory and start the full pipeline w
 - `fuzzware-project/mainXXX/fuzzers/fuzzerY/queue`: Fuzzer inputs
 - `fuzzware-project/mainXXX/fuzzers/fuzzerY/traces`: Pipeline-generated compact traces (detailed traces can be generated manually using `fuzzware replay` or `fuzzware emu`)
 
-For more information on the results stored in the `fuzzware-project` directory, refer to the pipeline's README [pipeline/README.md](https://github.com/fuzzware-fuzzer/fuzzware-pipeline/blob/main/README.md).
+For more information on the results stored in the `fuzzware-project` directory, refer to the pipeline's README [fuzzware-pipeline/README.md](https://github.com/fuzzware-fuzzer/fuzzware-pipeline/blob/main/README.md).
 
 There are situations where you might want to use a sub-component in isolation. This may be the case for troubleshooting, debugging, crash triaging and during fuzzware development. For a full list of supported commands, use:
 ```

--- a/docs/target_configuration.md
+++ b/docs/target_configuration.md
@@ -4,7 +4,7 @@ After building a firmware sample, we need to set it up for fuzzing initially. Af
 
 In general, while many of the following configuration options are not strictly required to fuzz test a sample, stacking as many configurations as possible for a given target will improve fuzzing performance significantly. In the end, the more firmware-specific quirks and overhead we can get rid of, the more we can focus the fuzzer on the functionality we are interested in. This will translate into the firmware behaving more and more like an ordinary command-line tool under test, making the fuzzer all the more effective in a practical setting.
 
-There are some configuration options which are not discussed here. Also refer to [/emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml) for additional options (and if you are really interested, the [code implementing the configuration parsing](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/harness/fuzzware_harness/harness.py) in the emulator to make sure we did not miss anything important).
+There are some configuration options which are not discussed here. Also refer to [fuzzware-emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml) for additional options (and if you are really interested, the [code implementing the configuration parsing](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/harness/fuzzware_harness/harness.py) in the emulator to make sure we did not miss anything important).
 
 # Automated Configuration: fuzzware genconfig
 To configure a firmware image, the `fuzzware genconfig` utility might be a good starting point. This will generate a configuration file with a best-effort memory map (for ELF files this will be derived from ELF sections and Cortex-M standard memory ranges) and run sample inputs to detect very early crashes in an effort to identify and configure custom MMIO ranges. **CAUTION: Do NOT use this generated configuration without manually verifying it. While the utility may work well for some cases, it will fail in others.**
@@ -14,7 +14,7 @@ One specific thing to watch out for here is memory ranges named in the following
 # Manual Base Config
 As also indicated in the [top-level README](../README.md), we can also create a configuration manually:
 
-Find a detailed overview of configuration options in [emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml).
+Find a detailed overview of configuration options in [fuzzware-emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml).
 
 At minimum, you will need a bare-metal firmware blob and know where it is located in memory. With this, you can setup a memory map. For a firmware blob `fw.bin` located at address `0x08000000` in ROM, a config located in a newly created `examples/my-fw` directory would look like this:
 ```
@@ -33,11 +33,11 @@ memory_map:
 
 # Optimizing Interrupt Behavior
 
-A default, catch-all interrupt behavior is just raising one interrupt every 1000 basic blocks in a round-robin fashion. Refer to [emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml) on the exact ways of how interrupts can be configured.
+A default, catch-all interrupt behavior is just raising one interrupt every 1000 basic blocks in a round-robin fashion. Refer to [fuzzware-emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml) on the exact ways of how interrupts can be configured.
 
 Depending on the architecture of your target code and the amount of knowledge you possess on it, you may apply more specific interrupt configurations, such as raising a specific interrupt when visiting a specific basic block, or letting the fuzzer decide based on fuzzing input which interrupt to trigger, instead of triggering all interrupt in a round-robin manner. Using fuzzing input to let the fuzzer decide about which interrupt to trigger leads to a tradeoff: On the one hand, it provides the fuzzer with more flexibility, but on the other hand it also forces more fuzzing input to be consumed.
 
-You can also disable a given interrupt in case you know it is either irrelevant to what you want to fuzz, or it is actively harming firmware execution (such as a triggering watchdog timer). You can do this via the `disabled_irqs` configuration (again, refer to [emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml) for details).
+You can also disable a given interrupt in case you know it is either irrelevant to what you want to fuzz, or it is actively harming firmware execution (such as a triggering watchdog timer). You can do this via the `disabled_irqs` configuration (again, refer to [fuzzware-emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml) for details).
 
 For an example of how we used triggering interrupts at the target OS'es idle loop, refer to the [fuzzware-experiment repo's CVE firmware setup](https://github.com/fuzzware-fuzzer/fuzzware-experiments/blob/main/03-fuzzing-new-targets/zephyr-os/building/base_configs/zephyr_default.yml).
 
@@ -128,7 +128,7 @@ boot:
   target: idle
 ```
 
-The above is an extract from the configuration README in [emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml).
+The above is an extract from the configuration README in [fuzzware-emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml).
 
 This configuration is picked up by `fuzzware pipeline` which checks each new basic block coverage trace to identify a successfully booting input. After identifying such an input, it will then configure it as a prefix input with the emulator for all coming configuration iterations. This essentially sets a snapshot to start at with the emulator, such that emulation in the fuzzer will always start at the configured `target` location automatically.
 
@@ -146,4 +146,4 @@ fuzzware genstats mmio-overhead-elim
 
 This produces a yaml file `fuzzware-project/stats/mmio_overhead_elimination.yml` which contains data about fuzzing input consumption per MMIO model. Most importantly (in this use case), it also shows which models consume the largest amounts of data. These models may be worth checking out manually to make sure that they are actually meaningful to fuzzing progress. Having the fuzzer mutate meaningless inputs most of the time will not help it discover meaningful firmware behavior. In case a highly-used MMIO model is not actually contributing to code coverage, we may want to manually configure this MMIO access to be modeled in a restrictive way (for example, by assigning a `constant` model to the respective pc/mmio_addr access context).
 
-The entry to search for within `fuzzware-project/stats/mmio_overhead_elimination.yml` is the `per_access_context` member with context entries that have a large `bytes_fuzzing_input` value assigned. After figuring out a fitting model type, you may manually assign an MMIO model according to [emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml). Upon start, the pipeline will take these custom MMIO model configs into account and regard them as definitive, meaning that it will not compute its own model for it.
+The entry to search for within `fuzzware-project/stats/mmio_overhead_elimination.yml` is the `per_access_context` member with context entries that have a large `bytes_fuzzing_input` value assigned. After figuring out a fitting model type, you may manually assign an MMIO model according to [fuzzware-emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml). Upon start, the pipeline will take these custom MMIO model configs into account and regard them as definitive, meaning that it will not compute its own model for it.

--- a/docs/target_configuration.md
+++ b/docs/target_configuration.md
@@ -4,7 +4,7 @@ After building a firmware sample, we need to set it up for fuzzing initially. Af
 
 In general, while many of the following configuration options are not strictly required to fuzz test a sample, stacking as many configurations as possible for a given target will improve fuzzing performance significantly. In the end, the more firmware-specific quirks and overhead we can get rid of, the more we can focus the fuzzer on the functionality we are interested in. This will translate into the firmware behaving more and more like an ordinary command-line tool under test, making the fuzzer all the more effective in a practical setting.
 
-There are some configuration options which are not discussed here. Also refer to [/emulator/README_config.yml](../emulator/README_config.yml) for additional options (and if you are really interested, the [code implementing the configuration parsing](../emulator/harness/fuzzware_harness/harness.py) in the emulator to make sure we did not miss anything important).
+There are some configuration options which are not discussed here. Also refer to [/emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml) for additional options (and if you are really interested, the [code implementing the configuration parsing](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/harness/fuzzware_harness/harness.py) in the emulator to make sure we did not miss anything important).
 
 # Automated Configuration: fuzzware genconfig
 To configure a firmware image, the `fuzzware genconfig` utility might be a good starting point. This will generate a configuration file with a best-effort memory map (for ELF files this will be derived from ELF sections and Cortex-M standard memory ranges) and run sample inputs to detect very early crashes in an effort to identify and configure custom MMIO ranges. **CAUTION: Do NOT use this generated configuration without manually verifying it. While the utility may work well for some cases, it will fail in others.**
@@ -14,7 +14,7 @@ One specific thing to watch out for here is memory ranges named in the following
 # Manual Base Config
 As also indicated in the [top-level README](../README.md), we can also create a configuration manually:
 
-Find a detailed overview of configuration options in [emulator/README_config.yml](../emulator/README_config.yml).
+Find a detailed overview of configuration options in [emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml).
 
 At minimum, you will need a bare-metal firmware blob and know where it is located in memory. With this, you can setup a memory map. For a firmware blob `fw.bin` located at address `0x08000000` in ROM, a config located in a newly created `examples/my-fw` directory would look like this:
 ```
@@ -33,13 +33,13 @@ memory_map:
 
 # Optimizing Interrupt Behavior
 
-A default, catch-all interrupt behavior is just raising one interrupt every 1000 basic blocks in a round-robin fashion. Refer to [emulator/README_config.yml](../emulator/README_config.yml) on the exact ways of how interrupts can be configured.
+A default, catch-all interrupt behavior is just raising one interrupt every 1000 basic blocks in a round-robin fashion. Refer to [emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml) on the exact ways of how interrupts can be configured.
 
 Depending on the architecture of your target code and the amount of knowledge you possess on it, you may apply more specific interrupt configurations, such as raising a specific interrupt when visiting a specific basic block, or letting the fuzzer decide based on fuzzing input which interrupt to trigger, instead of triggering all interrupt in a round-robin manner. Using fuzzing input to let the fuzzer decide about which interrupt to trigger leads to a tradeoff: On the one hand, it provides the fuzzer with more flexibility, but on the other hand it also forces more fuzzing input to be consumed.
 
-You can also disable a given interrupt in case you know it is either irrelevant to what you want to fuzz, or it is actively harming firmware execution (such as a triggering watchdog timer). You can do this via the `disabled_irqs` configuration (again, refer to [emulator/README_config.yml](../emulator/README_config.yml) for details).
+You can also disable a given interrupt in case you know it is either irrelevant to what you want to fuzz, or it is actively harming firmware execution (such as a triggering watchdog timer). You can do this via the `disabled_irqs` configuration (again, refer to [emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml) for details).
 
-For an example of how we used triggering interrupts at the target OS'es idle loop, refer to the [fuzzware-experiment repo's CVE firmware setup](https://github.com/fuzzware-fuzzer/fuzzware-experiments/03-fuzzing-new-targets/zephyr-os/building/base_configs/zephyr_default.yml).
+For an example of how we used triggering interrupts at the target OS'es idle loop, refer to the [fuzzware-experiment repo's CVE firmware setup](https://github.com/fuzzware-fuzzer/fuzzware-experiments/blob/main/03-fuzzing-new-targets/zephyr-os/building/base_configs/zephyr_default.yml).
 
 # Optimizing Fuzzer Performance
 
@@ -84,7 +84,7 @@ handlers:
         handler: native.inline_asm_7047
 ```
 
-For examples of how we used this type of configuration to save CPU cycles while discovering the CVE's of the paper, refer to the [fuzzware-experiment repo's CVE firmware setup](https://github.com/fuzzware-fuzzer/fuzzware-experiments/03-fuzzing-new-targets/zephyr-os/building/base_configs/zephyr_skips.yml) and its [crashing POC inputs](https://github.com/fuzzware-fuzzer/fuzzware-experiments/03-fuzzing-new-targets/zephyr-os/prebuilt_samples/CVE-2021-3329/POC)
+For examples of how we used this type of configuration to save CPU cycles while discovering the CVE's of the paper, refer to the [fuzzware-experiment repo's CVE firmware setup](https://github.com/fuzzware-fuzzer/fuzzware-experiments/blob/main/03-fuzzing-new-targets/zephyr-os/building/base_configs/zephyr_skips.yml) and its [crashing POC inputs](https://github.com/fuzzware-fuzzer/fuzzware-experiments/blob/main/03-fuzzing-new-targets/zephyr-os/prebuilt_samples/CVE-2021-3329/POC)
 
 ## Early Emulation Run Exits
 
@@ -98,7 +98,7 @@ exit_at:
 
 Again the philosophy here is that if we can avoid exiting specific functionality which we know not to be interested in, we can save precious CPU cycles, keep the fuzzer's attention away from useless code and keep it focussed on other functionality.
 
-For examples of how we used this type of configuration to save CPU cycles while discovering the CVE's of the paper, refer to the [fuzzware-experiment repo's CVE firmware setup](https://github.com/fuzzware-fuzzer/fuzzware-experiments/03-fuzzing-new-targets/zephyr-os/building/base_configs/zephyr_exits.yml) and its [crashing POC inputs](https://github.com/fuzzware-fuzzer/fuzzware-experiments/03-fuzzing-new-targets/zephyr-os/prebuilt_samples/CVE-2021-3329/POC)
+For examples of how we used this type of configuration to save CPU cycles while discovering the CVE's of the paper, refer to the [fuzzware-experiment repo's CVE firmware setup](https://github.com/fuzzware-fuzzer/fuzzware-experiments/blob/main/03-fuzzing-new-targets/zephyr-os/building/base_configs/zephyr_exits.yml) and its [crashing POC inputs](https://github.com/fuzzware-fuzzer/fuzzware-experiments/blob/main/03-fuzzing-new-targets/zephyr-os/prebuilt_samples/CVE-2021-3329/POC)
 
 ## Configuring the Boot Process
 
@@ -128,7 +128,7 @@ boot:
   target: idle
 ```
 
-The above is an extract from the configuration README in [emulator/README_config.yml](../emulator/README_config.yml).
+The above is an extract from the configuration README in [emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml).
 
 This configuration is picked up by `fuzzware pipeline` which checks each new basic block coverage trace to identify a successfully booting input. After identifying such an input, it will then configure it as a prefix input with the emulator for all coming configuration iterations. This essentially sets a snapshot to start at with the emulator, such that emulation in the fuzzer will always start at the configured `target` location automatically.
 
@@ -146,4 +146,4 @@ fuzzware genstats mmio-overhead-elim
 
 This produces a yaml file `fuzzware-project/stats/mmio_overhead_elimination.yml` which contains data about fuzzing input consumption per MMIO model. Most importantly (in this use case), it also shows which models consume the largest amounts of data. These models may be worth checking out manually to make sure that they are actually meaningful to fuzzing progress. Having the fuzzer mutate meaningless inputs most of the time will not help it discover meaningful firmware behavior. In case a highly-used MMIO model is not actually contributing to code coverage, we may want to manually configure this MMIO access to be modeled in a restrictive way (for example, by assigning a `constant` model to the respective pc/mmio_addr access context).
 
-The entry to search for within `fuzzware-project/stats/mmio_overhead_elimination.yml` is the `per_access_context` member with context entries that have a large `bytes_fuzzing_input` value assigned. After figuring out a fitting model type, you may manually assign an MMIO model according to [emulator/README_config.yml](../emulator/README_config.yml). Upon start, the pipeline will take these custom MMIO model configs into account and regard them as definitive, meaning that it will not compute its own model for it.
+The entry to search for within `fuzzware-project/stats/mmio_overhead_elimination.yml` is the `per_access_context` member with context entries that have a large `bytes_fuzzing_input` value assigned. After figuring out a fitting model type, you may manually assign an MMIO model according to [emulator/README_config.yml](https://github.com/fuzzware-fuzzer/fuzzware-emulator/blob/main/README_config.yml). Upon start, the pipeline will take these custom MMIO model configs into account and regard them as definitive, meaning that it will not compute its own model for it.


### PR DESCRIPTION
Note: Now some links are not relative anymore because this currently does not
work with submodules and how github handles relative links in *.md files.

But this still seems better than links that do not work at all.