### PR TITLE
Pin rq version

### DIFF
--- a/modeling/requirements.txt
+++ b/modeling/requirements.txt
@@ -1,5 +1,5 @@
 click==7.1.2
-rq
+rq~=1.16
 PyYAML>=5.3
 intelhex
 angr==9.2.61


### PR DESCRIPTION
Python `rq` version 2.0 removed `Connection` https://github.com/rq/rq/releases/tag/v2.0
This pins it to the latest 1.x version to keep the modeling worker functional