### PR TITLE
Support user ids different from 1000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update && \
 
 ENV FUZZWARE=/home/user/fuzzware
 ENV WORKON_HOME=/home/user/.virtualenvs
-RUN useradd -l -u 1000 -d /home/user user && \
+ARG USERID=1000
+RUN useradd -l -u $USERID -d /home/user user && \
     mkdir -p $FUZZWARE /home/user/.cache && \
     chown -R user:user /home/user && \
     echo "user ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -16,4 +16,4 @@ if [[ ! -e emulator/setup.sh || ! -e pipeline/setup.sh ]]; then
     echo "[ERROR] Could not pull emulator and pipeline repos, exiting."; exit 1
 fi
 
-docker build -t "fuzzware:$TAG" "$DIR"
+docker build -t "fuzzware:$TAG" --build-arg "USERID=$(id -u)" "$DIR"


### PR DESCRIPTION
When the host user does not have user id 1000, there will be issues when trying to run the docker container.

This patch assigns the same user id to the user in the container, when building it with `./build_docker.sh`.