### PR TITLE
Pin pycparser to 2.21 for modeling to fix angr incompatibility

### DIFF
--- a/modeling/requirements.txt
+++ b/modeling/requirements.txt
@@ -5,3 +5,4 @@ intelhex
 capstone==5.0.3
 angr==9.2.61
 IPython
+pycparser==2.21


### PR DESCRIPTION
`pycparser` 2.22+ made the filename attribute read-only, which breaks angr (v9.2.61) and causes the modeling worker to crash with an AttributeError: can't set attribute 'filename'. This results in:

```
Exception: 'modeling' worker spawned by WorkerPool is not running anymore
AttributeError: can't set attribute 'filename'
```

Pinning `pycparser==2.21` in `modeling/requirements.txt` fixes the crash and gets Fuzzware running again.