### PR TITLE
Pin redis to 5.2.0 for modeling to fix crash

### DIFF
--- a/modeling/requirements.txt
+++ b/modeling/requirements.txt
@@ -6,3 +6,4 @@ capstone==5.0.3
 angr==9.2.61
 IPython
 pycparser==2.21
+redis==5.2.0


### PR DESCRIPTION
Hi Tobi,

The default version of redis on Ubuntu 22.04 has been updated to 8.0.0, which appears to affect the modeling process https://github.com/fuzzware-fuzzer/fuzzware/issues/59#issuecomment-4808124064. I checked the worker_modeling_00.log and found that the issue was caused by a Redis timeout. Pinning Redis to v5.2.0 resolves the issue. Additional details are provided below.

## The default version of redis on Ubuntu 22.04
```
(fuzzware-modeling) root@90a91e04a48e:/home/user/fuzzware/targets# pip3 show redis
Name: redis
Version: 8.0.0
Summary: Python client for Redis database and key-value store
Home-page: https://github.com/redis/redis-py
Author:
Author-email: "Redis Inc." <oss@redis.com>
License-Expression: MIT
Location: /home/user/.virtualenvs/fuzzware-modeling/lib/python3.10/site-packages
Requires: async-timeout
Required-by: rq
```

## Modeling log (examples/pw-recovery/ARCH_PRO/fuzzware-project/logs/worker_modeling_00.log)
```
NFO     | 2026-06-27 02:17:53,269 | rq.worker      | modeling: Job OK (68ebe8f5-437f-4514-a5db-653556ff07ab)
INFO     | 2026-06-27 02:17:53,269 | rq.worker      | Result is kept for 86400 seconds
ERROR    | 2026-06-27 02:18:53,251 | rq.worker      | Worker rq:worker:deeede6ed5164568a55384c1183fe3fc: Redis connection timeout, quitting...
INFO     | 2026-06-27 02:18:53,255 | rq.worker      | Unsubscribing from channel rq:pubsub:deeede6ed5164568a55384c1183fe3fc
```